### PR TITLE
SQL syntax error

### DIFF
--- a/src/Install/Installer.php
+++ b/src/Install/Installer.php
@@ -218,12 +218,16 @@ class Installer
         $sqlStatements = Tools::file_get_contents($path);
         $sqlStatements = str_replace(['_DB_PREFIX_', '_MYSQL_ENGINE_'], [_DB_PREFIX_, _MYSQL_ENGINE_], $sqlStatements);
 
-        $status = $this->sqlExecute($db, $sqlStatements);
-
-        if (!$status) {
-            throw new \Exception();
+        $sqlStatementsArray = explode(";", $sqlStatements);
+        foreach($sqlStatementsArray as $sqlStatement){
+            $sqlStatement = trim($sqlStatement);
+            if(!empty($sqlStatement)){
+                $status = $this->sqlExecute($db, $sqlStatement.';');
+                if (!$status) {
+                    throw new \Exception();
+                }
+            }
         }
-
         return true;
     }
 


### PR DESCRIPTION
Podczas instalacji Prestashop zwraca poniższy błąd oraz nie są tworzone tabele w bazie danych poprzez funkcję installDb. You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'CREATE TABLE IF NOT EXISTS `ps_blue_gateway_transfers_shop`

Problemem jest przesyłanie jednocześnie całego pliku install.sql. Wprowadzona zmiana rozdziela polecenia sql i przesyła po kolei do bazy danych. 

Przetestowane na PrestaShop 1.7.8.8
PHP: 7.3.33