### PR TITLE
allow customized module path

### DIFF
--- a/src/Test/Checker/Transaction/ITN/ITNReturnUrlChecker.php
+++ b/src/Test/Checker/Transaction/ITN/ITNReturnUrlChecker.php
@@ -42,7 +42,7 @@ class ITNReturnUrlChecker implements CheckerInterface
     public function check(): array
     {
         $shopUrl = $this->context->shop->getBaseURL(true);
-        $returnUrl = $shopUrl . 'module/bluepayment/back';
+        $returnUrl = $shopUrl . strtok(\Configuration::get('PS_ROUTE_module'), '/') . '/bluepayment/back';
 
         $urlAccessibility = $this->checkUrlAccessibility($returnUrl);
 

--- a/src/Test/Checker/Transaction/ITN/ITNStatusUrlChecker.php
+++ b/src/Test/Checker/Transaction/ITN/ITNStatusUrlChecker.php
@@ -42,7 +42,7 @@ class ITNStatusUrlChecker implements CheckerInterface
     public function check(): array
     {
         $shopUrl = $this->context->shop->getBaseURL(true);
-        $itnUrl = $shopUrl . 'module/bluepayment/status';
+        $itnUrl = $shopUrl . strtok(\Configuration::get('PS_ROUTE_module'), '/') . '/bluepayment/status';
 
         $urlAccessibility = $this->checkUrlAccessibility($itnUrl);
 


### PR DESCRIPTION
Testing for connection will throw errors stating that "Return URL is not accessible" and "ITN Status URL is not accessible" when friendly links and custom module path is used. This patch makes them pass by using configured custom path (its first part) instead of hard coded one.